### PR TITLE
add mixed-precision support for particle data (#225)

### DIFF
--- a/main/src/io/file_utils.hpp
+++ b/main/src/io/file_utils.hpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <vector>
+#include <variant>
 
 namespace sphexa
 {
@@ -27,9 +28,9 @@ void writeColumns(std::ostream& out, const Separator& sep, Columns&&... columns)
  * @param   fields         pointers to field array, each field is a column
  * @param   separators     arbitrary number of separators to insert between columns, eg '\t', std::setw(n), ...
  */
-template<class T, class... Separators>
+template<class... T, class... Separators>
 void writeAscii(size_t firstIndex, size_t lastIndex, const std::string& path, bool append,
-                const std::vector<T*>& fields, Separators&&... separators)
+                const std::vector<std::variant<T*...>>& fields, Separators&&... separators)
 {
     std::ios_base::openmode mode;
     if (append) { mode = std::ofstream::app; }
@@ -47,7 +48,9 @@ void writeAscii(size_t firstIndex, size_t lastIndex, const std::string& path, bo
             for (auto field : fields)
             {
                 [[maybe_unused]] std::initializer_list<int> list{(dumpFile << separators, 0)...};
-                dumpFile << field[i];
+                std::visit([&dumpFile, i](auto& arg) {
+                    dumpFile << arg[i];
+                }, field);
             }
             dumpFile << std::endl;
         }

--- a/main/src/io/mpi_file_utils.hpp
+++ b/main/src/io/mpi_file_utils.hpp
@@ -3,6 +3,7 @@
 #ifdef SPH_EXA_HAVE_H5PART
 #include <filesystem>
 #include "H5Part.h"
+#include <variant>
 #endif
 
 namespace sphexa
@@ -29,6 +30,12 @@ std::vector<std::string> datasetNames(H5PartFile* h5_file)
     return setNames;
 }
 
+inline h5part_int64_t readH5PartField(H5PartFile* h5_file, const std::string& fieldName, int* field)
+{
+    static_assert(std::is_same_v<int, h5part_int32_t>);
+    return H5PartReadDataInt32(h5_file, fieldName.c_str(), field);
+}
+
 inline h5part_int64_t readH5PartField(H5PartFile* h5_file, const std::string& fieldName, float* field)
 {
     static_assert(std::is_same_v<float, h5part_float32_t>);
@@ -39,6 +46,12 @@ inline h5part_int64_t readH5PartField(H5PartFile* h5_file, const std::string& fi
 {
     static_assert(std::is_same_v<double, h5part_float64_t>);
     return H5PartReadDataFloat64(h5_file, fieldName.c_str(), field);
+}
+
+inline h5part_int64_t writeH5PartField(H5PartFile* h5_file, const std::string& fieldName, const int* field)
+{
+    static_assert(std::is_same_v<int, h5part_int32_t>);
+    return H5PartWriteDataInt32(h5_file, fieldName.c_str(), field);
 }
 
 inline h5part_int64_t writeH5PartField(H5PartFile* h5_file, const std::string& fieldName, const float* field)
@@ -118,7 +131,10 @@ void writeH5Part(Dataset& d, size_t firstIndex, size_t lastIndex, const cstone::
     for (size_t fidx = 0; fidx < fieldPointers.size(); ++fidx)
     {
         const std::string& fieldName = Dataset::fieldNames[d.outputFields[fidx]];
-        writeH5PartField(h5_file, fieldName, fieldPointers[fidx] + firstIndex);
+        std::visit([&h5_file, &fieldName, firstIndex](auto& arg)
+        {
+            writeH5PartField(h5_file, fieldName, arg + firstIndex);
+        }, fieldPointers[fidx]);
     }
 
     H5PartCloseFile(h5_file);

--- a/sph/include/sph/data_util.hpp
+++ b/sph/include/sph/data_util.hpp
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <vector>
+#include <variant>
 
 #include "traits.hpp"
 
@@ -65,13 +66,17 @@ auto getOutputArrays(Dataset& dataset)
 {
     using T            = typename Dataset::RealType;
     auto fieldPointers = dataset.data();
+    using FieldType = std::variant<const float*, const double*, const int*>;
 
-    std::vector<const T*> outputFields(dataset.outputFields.size());
-    std::transform(dataset.outputFields.begin(),
-                   dataset.outputFields.end(),
-                   outputFields.begin(),
-                   [&fieldPointers](int i) { return fieldPointers[i]->data(); });
-
+    std::vector<FieldType> outputFields;
+    outputFields.reserve(dataset.outputFields.size());
+    
+    for (int i : dataset.outputFields)
+    {
+        std::visit([&outputFields](auto& arg) {
+            outputFields.push_back(arg->data());
+        }, fieldPointers[i]);
+    }
     return outputFields;
 }
 
@@ -88,11 +93,15 @@ void resize(Dataset& d, size_t size)
 
     for (int i : d.conservedFields)
     {
-        reallocate(*data_[i], size, growthRate);
+        std::visit([size, growthRate](auto& arg) {
+            reallocate(*arg, size, growthRate);
+        }, data_[i]);
     }
     for (int i : d.dependentFields)
     {
-        reallocate(*data_[i], size, growthRate);
+        std::visit([size, growthRate](auto& arg) {
+            reallocate(*arg, size, growthRate);
+        }, data_[i]);
     }
 
     reallocate(d.codes, size, growthRate);

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -33,6 +33,7 @@
 #include <cstdio>
 #include <iostream>
 #include <vector>
+#include <variant>
 
 #include "sph/kernels.hpp"
 #include "sph/tables.hpp"
@@ -115,7 +116,9 @@ public:
      */
     auto data()
     {
-        std::array<std::vector<T>*, fieldNames.size()> ret{
+        using FieldType = std::variant<std::vector<float>*, std::vector<double>*, std::vector<int>*>;
+
+        std::array<FieldType, fieldNames.size()> ret{
             &x,   &y,        &z,        &x_m1,     &y_m1, &z_m1,  &vx, &vy,      &vz,   &rho,   &u,    &p,   &h,   &m,
             &c,   &grad_P_x, &grad_P_y, &grad_P_z, &du,   &du_m1, &dt, &dt_m1,   &c11,  &c12,   &c13,  &c22, &c23, &c33,
             &mue, &mui,      &temp,     &cv,       &rho0, &wrho0, &kx, &whomega, &divv, &curlv, &alpha};


### PR DESCRIPTION
* add mixed-precision support for particle data

* fix missing leftover include

* remove unused var passing

* fix pointer types as const, naming and iteration

* fix generic writeAscii func

* include variant header to data_util

Co-authored-by: Sebastian Keller <44800242+sebkelle1@users.noreply.github.com>